### PR TITLE
Misc fixes necessary to run

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,7 @@
     },
     "runArgs": [
         "--net=host",
-        "--env-file=${localEnv:HOME}/.gpt/token.env",
+        "--env-file=.env",
         "-v=${localEnv:HOME}/.ssh:/root/.ssh"
     ],
     "mounts": [

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ app/gpt_outputs/
 **.temp**
 # visualizing aut files
 out.html
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
+ARG PYTHON_IMAGE=python:3.11-bookworm
 ARG BUILD_SPOT=false
 ARG SPOT_VERSION=2.13.1
 
-FROM python:3.11 AS builder
+FROM ${PYTHON_IMAGE} AS builder
 
 # install requirements through pip
 COPY requirements.txt /requirements.txt
 RUN python -m pip install -r /requirements.txt
 
-FROM python:3.11 AS base
+FROM ${PYTHON_IMAGE} AS base
 
 ARG BUILD_SPOT
 ARG SPOT_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+ARG BUILD_SPOT=false
+ARG SPOT_VERSION=2.13.1
+
 FROM python:3.11 AS builder
 
 # install requirements through pip
@@ -6,39 +9,34 @@ RUN python -m pip install -r /requirements.txt
 
 FROM python:3.11 AS base
 
+ARG BUILD_SPOT
+ARG SPOT_VERSION
+
+ENV MAKEFLAGS="-j4"
+
+RUN apt-get update && apt-get install -y spin
+
+RUN if test "$BUILD_SPOT" = "true"; then \
+        echo "Building SPOT from source..." && \
+        curl -O https://www.lrde.epita.fr/dload/spot/spot-${SPOT_VERSION}.tar.gz && \
+        tar xzf spot-${SPOT_VERSION}.tar.gz && cd spot-${SPOT_VERSION} && \
+        ./configure && make && make install; \
+    else \
+        curl -o - https://www.lrde.epita.fr/repo/debian.gpg | apt-key add - && \
+        echo 'deb http://www.lrde.epita.fr/repo/debian/ stable/' >> /etc/apt/sources.list && \
+        apt-get update && \
+        apt-get install -y spot libspot-dev python3-spot; \
+    fi
+
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"
+
 # top line is general software dev tools, second is for spin, third is for spot
 RUN apt-get -y update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common build-essential wget netcat-openbsd vim \
     byacc flex graphviz
-    # see comment below about SPOT
-    # bison swig latexmk texlive-latex-extra texlive-fonts-extra fonts-roboto texlive-science pdf2svg groff r-base
-
-# NOTE: sometimes the GPG key goes down from SPOT so we have to build manually. Keep as backup.
-# COPY spot-spot-2-12-2.tar /spot-spot-2-12-2.tar
-# spot install from source. for some reason apt isn't working with keys
-# RUN tar -xf /spot-spot-2-12-2.tar && cd spot-spot-2-12-2 \
-#     export MAKEFLAGS='-j8' NBPROC='8' && \
-#     # autoreconf -vfi && ./configure --enable-max-accsets=256 --enable-pthread && \
-#     make
-# ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"
-
-# install SPOT w/ python bindings from apt
-RUN wget -q -O - https://www.lrde.epita.fr/repo/debian.gpg | apt-key add - && \
-    echo 'deb http://www.lrde.epita.fr/repo/debian/ stable/' >> /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y spot libspot-dev spot-doc python3-spot
 
 # SPOT package is installed into python3 folder, not python3.11
 ENV PYTHONPATH "/usr/lib/python3/dist-packages:$PYTHONPATH"
-
-# install spin -> prebuilt image
-RUN wget https://github.com/nimble-code/Spin/archive/refs/tags/version-6.5.2.tar.gz && \
-    gunzip *.tar.gz && \
-    tar -xf *.tar && \
-    cd Spin-version-6.5.2/Bin && \
-    gunzip spin651_linux64.gz && \
-    ./spin651_linux64 -V && \
-    mv ./spin651_linux64 /usr/local/bin/spin
 
 # For more information, please refer to https://aka.ms/vscode-docker-python
 # This is particularly for debugging using VSCode

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ bash:
 		--platform=$(PLATFORM) \
 		-v ./Makefile:/${REPO_NAME}/Makefile:Z \
 		-v ./app/:/${REPO_NAME}/app:Z \
-		--env-file ~/.gpt/token.env \
+		--env-file .env \
 		--net=host \
 		${CONTAINER_NAME} \
 		/bin/bash

--- a/Makefile
+++ b/Makefile
@@ -2,21 +2,38 @@ CONTAINER_NAME := gpt-mission-planner
 REPO_NAME := gpt-mission-planner
 CONFIG := ./app/config/localhost.yaml
 
+# set PLATFORM to linux/arm64 on silicon mac, otherwise linux/amd64
+ARCH := $(shell uname -m)
+PLATFORM := linux/amd64
+ifeq ($(ARCH),arm64)
+	PLATFORM := linux/arm64
+endif
+
+# use prebuilt SPOT on x86 and x64, otherwise build from source
+BUILD_SPOT ?= true
+ifneq ($(filter $(ARCH),x86_64 i386),)
+	BUILD_SPOT := false
+endif
+
 repo-init:
 	python3 -m pip install pre-commit==3.4.0 && \
 	pre-commit install
 
 build-image:
-	docker build . -t ${CONTAINER_NAME} --target local
+	docker buildx build --load \
+		--platform=$(PLATFORM) \
+		--build-arg BUILD_SPOT=$(BUILD_SPOT) \
+		. -t ${CONTAINER_NAME} --target local
 
 bash:
 	docker run -it --rm \
-	-v ./Makefile:/${REPO_NAME}/Makefile:Z \
-	-v ./app/:/${REPO_NAME}/app:Z \
-	--env-file ~/.gpt/token.env \
-	--net=host \
-	${CONTAINER_NAME} \
-	/bin/bash
+		--platform=$(PLATFORM) \
+		-v ./Makefile:/${REPO_NAME}/Makefile:Z \
+		-v ./app/:/${REPO_NAME}/app:Z \
+		--env-file ~/.gpt/token.env \
+		--net=host \
+		${CONTAINER_NAME} \
+		/bin/bash
 
 run:
 	python3 ./app/mission_planner.py --config ${CONFIG}

--- a/Makefile
+++ b/Makefile
@@ -39,4 +39,4 @@ run:
 	python3 ./app/mission_planner.py --config ${CONFIG}
 
 server:
-	nc -l 0.0.0.0 12346
+	while true; do nc -l 0.0.0.0 12346; done

--- a/Makefile
+++ b/Makefile
@@ -39,4 +39,4 @@ run:
 	python3 ./app/mission_planner.py --config ${CONFIG}
 
 server:
-	while true; do nc -l 0.0.0.0 12346; done
+	nc -lk 0.0.0.0 12346

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ ANTHROPIC_API_KEY=<my_token_here>
 ```
 
 ### Docker
-NOTE: if running on Mac, ensure you have network mode enabled for this to work. This capability is only available on version 4.29+ of Docker Desktop.
-If working in Linux, will work on any version.
 
 On arm macs, SPOT will be built from source. If necessary, you can force building SPOT from source on x86/64 by running `make build-image BUILD_SPOT=true`.
+
+On linux, you may need to install `netcat-openbsd`.
 
 ```bash
 $ make build-image

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ make repo-init
 
 ## How To Run GPT Mission Planner
 ### GPT Token
-Create a file at `~/.gpt/token.env` and add your token in environment variable structure:
+Create a `.env` file and add your API tokens:
 ```bash
 OPENAI_API_KEY=<my_token_here>
+ANTHROPIC_API_KEY=<my_token_here>
 ```
 
 ### Docker
@@ -66,7 +67,7 @@ $ make bash
 docker run -it --rm \
         -v ./Makefile:/gpt-mission-planner/Makefile:Z \
         -v ./app/:/gpt-mission-planner/app:Z \
-        --env-file ~/.gpt/token.env \
+        --env-file .env \
         --net=host \
         gpt-mission-planner \
         /bin/bash

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ OPENAI_API_KEY=<my_token_here>
 NOTE: if running on Mac, ensure you have network mode enabled for this to work. This capability is only available on version 4.29+ of Docker Desktop.
 If working in Linux, will work on any version.
 
+On arm macs, SPOT will be built from source. If necessary, you can force building SPOT from source on x86/64 by running `make build-image BUILD_SPOT=true`.
+
 ```bash
 $ make build-image
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ ANTHROPIC_API_KEY=<my_token_here>
 
 ### Docker
 
-On arm macs, SPOT will be built from source. If necessary, you can force building SPOT from source on x86/64 by running `make build-image BUILD_SPOT=true`.
+On ARM Macs, SPOT will be built from source. If necessary, you can force building SPOT from source on x86/64 by running `make build-image BUILD_SPOT=true`.
 
 On linux, you may need to install `netcat-openbsd`.
 

--- a/app/config/husky01.yaml
+++ b/app/config/husky01.yaml
@@ -1,6 +1,6 @@
 logging: DEBUG
 # OpenAI API token
-token: "~/.gpt/token.env"
+token: ".env"
 # max number of retries to get a valid mission plan from ChatGPT
 max_retries: 1
 max_tokens: 2000

--- a/app/config/husky_fv.yaml
+++ b/app/config/husky_fv.yaml
@@ -1,6 +1,6 @@
 logging: DEBUG
 # OpenAI API token
-token: "~/.gpt/token.env"
+token: ".env"
 # max number of retries to get a valid mission plan from ChatGPT
 max_retries: 10
 # config for GPT

--- a/app/config/kinova.yaml
+++ b/app/config/kinova.yaml
@@ -1,6 +1,6 @@
 logging: DEBUG
 # OpenAI API token
-token: "~/.gpt/token.env"
+token: ".env"
 # max number of retries to get a valid mission plan from ChatGPT
 max_retries: 3
 max_tokens: 4096

--- a/app/config/kinova_husky.yaml
+++ b/app/config/kinova_husky.yaml
@@ -1,6 +1,6 @@
 logging: DEBUG
 # OpenAI API token
-token: "~/.gpt/token.env"
+token: ".env"
 # max number of retries to get a valid mission plan from ChatGPT
 max_retries: 5
 max_tokens: 4096

--- a/app/config/localhost.yaml
+++ b/app/config/localhost.yaml
@@ -1,6 +1,6 @@
 logging: DEBUG
-# OpenAI API token
-token: "~/.gpt/token.env"
+# API tokens
+token: ".env"
 # max number of retries to get a valid mission plan from ChatGPT
 max_retries: 2
 max_tokens: 4000

--- a/app/config/localhost.yaml
+++ b/app/config/localhost.yaml
@@ -12,9 +12,9 @@ schema:
 context_files:
   - "./app/resources/context/wheeled_bots/reza20.geojson"
 # who to send this too?
-host: 127.0.0.1
+host: host.docker.internal
 port: 12346
 # LTL generation?
-ltl: True
-promela_template: "./app/resources/specs/promela_template.txt"
-spin_path: "/Users/marcos/Desktop/spin"
+ltl: False
+promela_template: "./app/resources/context/wheeled_bots/promela_template.txt"
+spin_path: "/usr/bin/spin"

--- a/app/mission_planner.py
+++ b/app/mission_planner.py
@@ -153,7 +153,7 @@ class MissionPlanner:
                         continue
                     self.ltl_valid = True
                 # preliminary check, but can be improved to be more thorough
-                if ltl_task_count != xml_task_count:
+                if self.ltl and ltl_task_count != xml_task_count:
                     reconsider: str = (
                         f"You and another agent generated a different number of tasks for this mission. Reconsider and give me another answer."
                     )
@@ -209,7 +209,8 @@ class MissionPlanner:
 
             # clear before new query
             self.gpt.reset_context(self.gpt.initial_context_length)
-            self.pml_gpt.reset_context(self.pml_gpt.initial_context_length)
+            if self.ltl:
+                self.pml_gpt.reset_context(self.pml_gpt.initial_context_length)
 
         # TODO: decide how the reuse flow works
         self.nic.close_socket()


### PR DESCRIPTION
These commits make various fixes that are necessary in order for the program to run on my machine. With these, I am able to simply populate a .env file, run `make server` in a shell, and `make bash` followed by `make run` in a second shell.

This builds on #7. Again, tested only on arm mac.

Note that this disables spin/et al by default. Enabling does not seem to work for me currently; I have this mostly fixed and will follow up with another PR (probably tomorrow).